### PR TITLE
fix: Resolve Vercel deployment errors

### DIFF
--- a/frontend/src/components/dashboard/ProjectList.tsx
+++ b/frontend/src/components/dashboard/ProjectList.tsx
@@ -25,7 +25,7 @@ export default function ProjectList() {
 
     setLoading(true);
     try {
-      const response = await fetch('http://localhost:8000/projects', {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/projects`, {
         headers: {
           'Authorization': `Bearer ${session.access_token}`,
         },

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,10 @@
 {
+  "name": "devyntra",
   "builds": [
     {
       "src": "frontend/package.json",
       "use": "@vercel/next"
     }
-  ]
+  ],
+  "root": "frontend"
 }


### PR DESCRIPTION
This commit fixes two issues that were causing deployment failures on Vercel:

1.  **Incorrect `vercel.json` configuration:** The `vercel.json` file was missing the `root` property, which is required for Vercel to correctly build and deploy a frontend application from a monorepo. This has been corrected by adding `"root": "frontend"`.

2.  **Hardcoded API endpoint:** The frontend application was using a hardcoded `http://localhost:8000` URL to fetch data from the backend. This has been replaced with the `NEXT_PUBLIC_API_URL` environment variable to allow for flexible configuration in different environments.